### PR TITLE
Issue remaining work

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <!-- <link rel="icon" type="image/svg+xml" href="/vite.svg" /> -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'self';" />
     <title>Report builder</title>
   </head>
   <body>

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "ci": "npm run type-check && npm run lint && npm run test",
+    "audit": "npm audit",
+    "audit:fix": "npm audit fix",
     "check": "npm run ci",
     "check:full": "npm run type-check && npm run lint && npm run test && vite build",
     "format": "prettier . --write",

--- a/src/components/TipTapEditor.tsx
+++ b/src/components/TipTapEditor.tsx
@@ -49,6 +49,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
+import { isValidHref } from "@/lib/urlValidation";
 import { cn } from "@/lib/utils";
 
 interface TipTapEditorProps {
@@ -111,7 +112,7 @@ const EditorMenuBar = ({
 
   const addLink = () => {
     const url = window.prompt(t("editor.enterUrl"));
-    if (url) {
+    if (url && isValidHref(url)) {
       editor.chain().focus().setLink({ href: url }).run();
     }
   };

--- a/src/components/rich-text-editor/InlineSectionEditor.tsx
+++ b/src/components/rich-text-editor/InlineSectionEditor.tsx
@@ -60,6 +60,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
+import { isValidHref } from "@/lib/urlValidation";
 import { cn } from "@/lib/utils";
 
 import { ImageResizeWithAlign } from "./ImageResizeWithAlign";
@@ -192,8 +193,8 @@ export const InlineSectionEditor = ({
 
   const addLink = () => {
     if (!editor) return;
-    const url = window.prompt("Enter URL:");
-    if (url) {
+    const url = window.prompt(t("editor.enterUrl"));
+    if (url && isValidHref(url)) {
       editor.chain().focus().setLink({ href: url }).run();
     }
   };

--- a/src/lib/documentStorage.ts
+++ b/src/lib/documentStorage.ts
@@ -3,6 +3,7 @@ import {
   EMPTY_SECTION_CONTENT,
   normalizeSections,
 } from "@/lib/sectionHierarchy";
+import { sanitizeTagValues } from "@/lib/tagValidation";
 
 import type { Document, Section, Template } from "@/types/document";
 
@@ -2390,7 +2391,7 @@ export const loadDocument = (): Document => {
           id: parsed.id,
           title: parsed.title,
           sections: normalizeSections(normalizedSections),
-          tagValues: parsed.tagValues as Record<string, string>,
+          tagValues: sanitizeTagValues(parsed.tagValues as Record<string, string>),
         };
       }
     }
@@ -2402,7 +2403,11 @@ export const loadDocument = (): Document => {
 
 export const saveDocument = (document: Document): void => {
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(document));
+    const sanitized = {
+      ...document,
+      tagValues: sanitizeTagValues(document.tagValues),
+    };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(sanitized));
   } catch (error) {
     console.error("Error saving document:", error);
   }

--- a/src/lib/pdfExport.test.ts
+++ b/src/lib/pdfExport.test.ts
@@ -184,7 +184,11 @@ describe("exportToPDF", () => {
 
     container = document.createElement("div");
     const paragraph = document.createElement("p");
-    paragraph.innerHTML = "Line 1<br>Line 2<br>Line 3";
+    paragraph.appendChild(document.createTextNode("Line 1"));
+    paragraph.appendChild(document.createElement("br"));
+    paragraph.appendChild(document.createTextNode("Line 2"));
+    paragraph.appendChild(document.createElement("br"));
+    paragraph.appendChild(document.createTextNode("Line 3"));
     container.appendChild(paragraph);
     document.body.appendChild(container);
 
@@ -240,7 +244,10 @@ describe("exportToPDF", () => {
 
     container = document.createElement("div");
     const paragraph = document.createElement("p");
-    paragraph.innerHTML = "Line 1<br><br>Line 3";
+    paragraph.appendChild(document.createTextNode("Line 1"));
+    paragraph.appendChild(document.createElement("br"));
+    paragraph.appendChild(document.createElement("br"));
+    paragraph.appendChild(document.createTextNode("Line 3"));
     container.appendChild(paragraph);
     document.body.appendChild(container);
 

--- a/src/lib/tagValidation.test.ts
+++ b/src/lib/tagValidation.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+
+import { sanitizeTagValue, sanitizeTagValues } from "./tagValidation";
+
+describe("sanitizeTagValue", () => {
+  it("returns empty string for non-string input", () => {
+    expect(sanitizeTagValue(null as unknown as string)).toBe("");
+    expect(sanitizeTagValue(undefined as unknown as string)).toBe("");
+  });
+
+  it("strips control characters", () => {
+    expect(sanitizeTagValue("Hello\x00World\x1F")).toBe("HelloWorld");
+    expect(sanitizeTagValue("Tab\there")).toBe("Tabhere");
+  });
+
+  it("truncates to max length", () => {
+    const long = "a".repeat(600);
+    expect(sanitizeTagValue(long).length).toBe(500);
+  });
+
+  it("preserves normal content", () => {
+    expect(sanitizeTagValue("Acme AB")).toBe("Acme AB");
+    expect(sanitizeTagValue("556677-8899")).toBe("556677-8899");
+  });
+});
+
+describe("sanitizeTagValues", () => {
+  it("sanitizes all values in record", () => {
+    const input = {
+      CompanyName: "Acme\x00AB",
+      OrgNumber: "556677-8899",
+    };
+    expect(sanitizeTagValues(input)).toEqual({
+      CompanyName: "AcmeAB",
+      OrgNumber: "556677-8899",
+    });
+  });
+
+  it("skips invalid keys", () => {
+    const input = { "": "value", valid: "ok" };
+    expect(sanitizeTagValues(input)).toEqual({ valid: "ok" });
+  });
+});

--- a/src/lib/tagValidation.ts
+++ b/src/lib/tagValidation.ts
@@ -1,0 +1,32 @@
+/** Max length for a single tag value (e.g. company name, org number). */
+const MAX_TAG_VALUE_LENGTH = 500;
+
+/**
+ * Sanitizes a single tag value: strips control chars and truncates to max length.
+ */
+export function sanitizeTagValue(value: string): string {
+  if (typeof value !== "string") return "";
+  const stripped = value
+    .split("")
+    .filter((c) => {
+      const code = c.charCodeAt(0);
+      return code >= 32 && code !== 127;
+    })
+    .join("");
+  return stripped.slice(0, MAX_TAG_VALUE_LENGTH);
+}
+
+/**
+ * Sanitizes all values in a tagValues record.
+ */
+export function sanitizeTagValues(
+  tagValues: Record<string, string>
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(tagValues)) {
+    if (typeof key === "string" && key.length > 0) {
+      result[key] = sanitizeTagValue(value);
+    }
+  }
+  return result;
+}

--- a/src/lib/urlValidation.test.ts
+++ b/src/lib/urlValidation.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+
+import { isValidHref } from "./urlValidation";
+
+describe("isValidHref", () => {
+  it("rejects javascript: URLs", () => {
+    expect(isValidHref("javascript:alert(1)")).toBe(false);
+    expect(isValidHref("JavaScript:void(0)")).toBe(false);
+  });
+
+  it("rejects vbscript: URLs", () => {
+    expect(isValidHref("vbscript:msgbox(1)")).toBe(false);
+  });
+
+  it("rejects data: URLs", () => {
+    expect(isValidHref("data:text/html,<script>alert(1)</script>")).toBe(false);
+    expect(isValidHref("data:image/png;base64,abc")).toBe(false);
+  });
+
+  it("allows https URLs", () => {
+    expect(isValidHref("https://example.com")).toBe(true);
+    expect(isValidHref("https://example.com/path")).toBe(true);
+  });
+
+  it("allows http URLs", () => {
+    expect(isValidHref("http://example.com")).toBe(true);
+  });
+
+  it("allows mailto URLs", () => {
+    expect(isValidHref("mailto:user@example.com")).toBe(true);
+  });
+
+  it("allows relative paths", () => {
+    expect(isValidHref("/about")).toBe(true);
+    expect(isValidHref("#section")).toBe(true);
+    expect(isValidHref("about")).toBe(true);
+    expect(isValidHref("./page")).toBe(true);
+  });
+
+  it("rejects empty or whitespace-only strings", () => {
+    expect(isValidHref("")).toBe(false);
+    expect(isValidHref("   ")).toBe(false);
+  });
+});

--- a/src/lib/urlValidation.ts
+++ b/src/lib/urlValidation.ts
@@ -1,0 +1,17 @@
+/**
+ * Validates href values to prevent XSS via javascript:, vbscript:, data: URIs.
+ * Allows only http:, https:, mailto:, and relative paths.
+ */
+export function isValidHref(url: string): boolean {
+  const trimmed = url.trim();
+  if (!trimmed) return false;
+  // Reject dangerous schemes
+  if (/^(javascript|vbscript|data):/i.test(trimmed)) return false;
+  // Allow http, https, mailto, and relative paths (starts with / or # or no scheme)
+  return (
+    /^https?:\/\//i.test(trimmed) ||
+    /^mailto:/i.test(trimmed) ||
+    /^[/#]/.test(trimmed) ||
+    !/^[a-z][a-z0-9+.-]*:/i.test(trimmed)
+  );
+}

--- a/src/pages/DocumentEditor.tsx
+++ b/src/pages/DocumentEditor.tsx
@@ -31,6 +31,7 @@ import {
   type SectionDragItem,
   type SectionKind,
 } from "@/lib/sectionHierarchy";
+import { sanitizeTagValue } from "@/lib/tagValidation";
 
 import type { Document, Section, Template } from "@/types/document";
 
@@ -551,7 +552,7 @@ export const DocumentEditor = () => {
       ...prev,
       tagValues: {
         ...prev.tagValues,
-        [editingTagKey]: tagValue,
+        [editingTagKey]: sanitizeTagValue(tagValue),
       },
     }));
 
@@ -567,7 +568,7 @@ export const DocumentEditor = () => {
       ...prev,
       tagValues: {
         ...prev.tagValues,
-        [newTagKey]: newTagValue,
+        [newTagKey.trim()]: sanitizeTagValue(newTagValue),
       },
     }));
 


### PR DESCRIPTION
Implements all remaining security hardening fixes from Issue #31.

This PR addresses the five outstanding items from Issue #31: link URL validation (XSS prevention), adding a Content-Security-Policy meta tag, sanitizing tag/mention values, adding `npm audit` scripts, and replacing `innerHTML` in tests.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-b89a6fd0-6725-4b8b-9c80-84d615d49cc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b89a6fd0-6725-4b8b-9c80-84d615d49cc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens client-side security controls (CSP, URL and tag sanitization), which can inadvertently block legitimate external resources or change persisted user data formatting. Main functional risk is regressions around link insertion and loading/saving existing documents with unsanitized `tagValues`.
> 
> **Overview**
> **Security hardening across the editor and persistence layer.** Adds a `Content-Security-Policy` meta tag and new `npm audit`/`npm audit fix` scripts.
> 
> Introduces `isValidHref` URL validation (with tests) and gates link creation in both TipTap editors to reject dangerous schemes like `javascript:`/`data:`.
> 
> Adds `sanitizeTagValue`/`sanitizeTagValues` (with tests) and applies sanitization when editing/adding tags in `DocumentEditor` and when loading/saving documents in `documentStorage`.
> 
> Updates PDF export tests to avoid `innerHTML` usage by constructing DOM nodes directly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65c66e3ad200b5a36dc5db230dd8281b41490f45. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->